### PR TITLE
Расширен функционал GitLabHTTP + добавлен первый интеграционный тест

### DIFF
--- a/.github/workflows/pull_request.yml
+++ b/.github/workflows/pull_request.yml
@@ -22,3 +22,4 @@ jobs:
       python_version: "3.12"
       packaging_with: "poetry"
       from: "tests"
+      flags: "-m 'not integration'"

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,4 @@ cython_debug/
 #  and can be added to the global gitignore or merged into this file.  For a more nuclear
 #  option (not recommended) you can uncomment the following to ignore the entire idea folder.
 .idea/
+.gitlab_srv/

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,6 +64,15 @@ max-args = 10
 [tool.ruff.pydocstyle]
 convention = "google"
 
+[tool.pytest.ini_options]
+markers = [
+    "integration: marks integration tests (deselect with '-m \"not integration\"')",
+]
+filterwarnings = [
+    "ignore: Inheritance class FakeClientSession from ClientSession is discouraged",
+]
+asyncio_mode = "auto"
+
 [tool.coverage.run]
 data_file = ".coverage/coverage"
 

--- a/src/repository/http_requests/base.py
+++ b/src/repository/http_requests/base.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import TYPE_CHECKING, Any
+from typing import TYPE_CHECKING, Any, Generic, TypeVar
 
 if TYPE_CHECKING:
     from collections.abc import Mapping
@@ -9,8 +9,11 @@ if TYPE_CHECKING:
     from aiohttp import ClientSession
 
 
+T = TypeVar("T")
+
+
 @dataclass
-class ResponseModel:
+class ResponseModel(Generic[T]):
     """Модель Response, возвращаемая BaseHTTP
 
     Args:
@@ -18,7 +21,7 @@ class ResponseModel:
         status_code: статус код HTTP ответа
         headers: заголовки HTTP ответа
     """
-    data: dict[str, Any] | list[dict[str, Any]]
+    data: T
     status_code: int
     headers: Mapping[str, str]
 
@@ -33,7 +36,7 @@ class BaseHTTP:
                    url: str,
                    params: dict[str, Any] | None = None,
                    headers: dict[str, Any] | None = None,
-                   ) -> ResponseModel:
+                   ) -> ResponseModel[Any]:
         """Реализация GET запроса
 
         Args:
@@ -53,9 +56,9 @@ class BaseHTTP:
 
     async def _post(self,
                     url: str,
-                    data: dict[str, Any] | None = None,
+                    data: dict[str, Any],
                     headers: dict[str, Any] | None = None,
-                    ) -> ResponseModel:
+                    ) -> ResponseModel[Any]:
         """Реализация POST запроса
 
         Args:
@@ -75,9 +78,9 @@ class BaseHTTP:
 
     async def _put(self,
                    url: str,
-                   data: dict[str, Any] | None = None,
+                   data: dict[str, Any],
                    headers: dict[str, Any] | None = None,
-                   ) -> ResponseModel:
+                   ) -> ResponseModel[Any]:
         """Реализация PUT запроса
 
         Args:
@@ -97,9 +100,9 @@ class BaseHTTP:
 
     async def _patch(self,
                      url: str,
-                     data: dict[str, Any] | None = None,
+                     data: dict[str, Any],
                      headers: dict[str, Any] | None = None,
-                     ) -> ResponseModel:
+                     ) -> ResponseModel[Any]:
         """Реализация PATCH запроса
 
         Args:
@@ -121,7 +124,7 @@ class BaseHTTP:
                       url: str,
                       params: dict[str, Any] | None = None,
                       headers: dict[str, Any] | None = None,
-                      ) -> ResponseModel:
+                      ) -> ResponseModel[Any]:
         """Реализация DELETE запроса
 
         Args:

--- a/src/repository/http_requests/gitlab.py
+++ b/src/repository/http_requests/gitlab.py
@@ -39,7 +39,7 @@ class UserModel(TypedDict):
     id: int
 
 
-class GitLabHTTP(BaseHTTP):
+class GitLabHTTPv4(BaseHTTP):
     """Запросы в GitLab API"""
     URL_PING = "/api/v4/projects"
     URL_ADD_USER_TO_GROUP = "/api/v4/groups/{group_id}/members"

--- a/src/repository/http_requests/gitlab.py
+++ b/src/repository/http_requests/gitlab.py
@@ -1,13 +1,252 @@
-from http import HTTPStatus
+from __future__ import annotations
 
-from .base import BaseHTTP
+from http import HTTPStatus
+from typing import Literal, TypedDict
+
+from .base import BaseHTTP, ResponseModel
+
+AccessLevel = Literal[0, 5, 10, 20, 30, 40, 50]
+
+
+class GitLabError(Exception):
+    """Базовый exception для GitLabHTTP"""
+
+
+class GroupModel(TypedDict):
+    """Модель описывающая группу в GitLab
+
+    Args:
+        id: идентификатор группы
+    """
+    id: int
+
+
+class ProjectModel(TypedDict):
+    """Модель описывающая репозиторий в GitLab
+
+    Args:
+        id: идентификатор репозитория
+    """
+    id: int
+
+
+class UserModel(TypedDict):
+    """Модель описывающая пользователя в GitLab
+
+    Args:
+        id: идентификатор пользователя
+    """
+    id: int
 
 
 class GitLabHTTP(BaseHTTP):
     """Запросы в GitLab API"""
-    PING = "/api/v4/projects"
+    URL_PING = "/api/v4/projects"
+    URL_ADD_USER_TO_GROUP = "/api/v4/groups/{group_id}/members"
+    URL_ADD_USER_TO_PROJECT = "/api/v4/projects/{project_id}/members"
+    URL_GROUPS = "/api/v4/groups"
+    URL_PROJECTS = "/api/v4/projects"
+    URL_USERS = "/api/v4/users"
 
     async def check(self) -> bool:
-        """Проверка доступности GitLab API"""
-        response = await self._get(self.PING)
+        """Проверка доступности GitLab API
+
+        Returns:
+            True - GitLab доступен, False - GitLab недоступен
+        """
+        response = await self._get(self.URL_PING)
         return response.status_code == HTTPStatus.OK and isinstance(response.data, list)
+
+    async def add_user_to_group(self,
+                                group_id: int,
+                                user_id: int,
+                                access_level: AccessLevel,
+                                ) -> int:
+        """Добавление пользователя к группе GitLab
+
+        Args:
+            group_id: идентификатор группы
+            user_id: идентификатор пользователя
+            access_level: уровень доступа
+
+        Returns:
+            идентификатор добавленного пользователя
+        """
+        url = self.URL_ADD_USER_TO_GROUP.format(group_id=group_id)
+        return await self._add_user(url, user_id, access_level)
+
+    async def add_user_to_project(self,
+                                  project_id: int,
+                                  user_id: int,
+                                  access_level: AccessLevel,
+                                  ) -> int:
+        """Добавление пользователя к репозиторию GitLab
+
+        Args:
+            project_id: идентификатор репозитория
+            user_id: идентификатор пользователя
+            access_level: уровень доступа
+
+        Returns:
+            идентификатор добавленного пользователя
+        """
+        url = self.URL_ADD_USER_TO_PROJECT.format(project_id=project_id)
+        return await self._add_user(url, user_id, access_level)
+
+    async def create_group(self,
+                           name: str,
+                           path: str,
+                           ) -> int:
+        """Создание группы в GitLab
+
+        Args:
+            name: наименование новой группы
+            path: путь до новой группы
+
+        Returns:
+            идентификатор созданной группы
+        """
+        return await self._create_group(name, path)
+
+    async def create_subgroup(self,
+                              name: str,
+                              path: str,
+                              parent_id: int,
+                              ) -> int:
+        """Создание подгруппы в GitLab
+
+        Args:
+            name: наименование новой подгруппы
+            path: путь до новой подгруппы
+            parent_id: идентификатор родительской группы
+
+        Returns:
+            идентификатор созданной подгруппы
+        """
+        return await self._create_group(name, path, parent_id)
+
+    async def create_project(self,
+                             name: str,
+                             path: str,
+                             *,
+                             initialize_with_readme: bool = True,
+                             only_allow_merge_if_all_discussions_are_resolved: bool = True,
+                             only_allow_merge_if_pipeline_succeeds: bool = True,
+                             ) -> int:
+        """Создание репозитория в GitLab
+
+        Args:
+            name: наименование нового репозитория
+            path: путь до нового репозитория
+            initialize_with_readme: True - инициализировать репозиторий в README.md файлом, False - без README.md
+            only_allow_merge_if_all_discussions_are_resolved: True - сливать MR можно только после разрешения
+                всех discussion под MR, False - можно сливать MR и без разрешения всех discussion
+            only_allow_merge_if_pipeline_succeeds: True - сливать MR можно только при success pipeline, False - можно
+                сливать MR и при fail pipeline
+
+        Returns:
+            идентификатор созданного репозитория
+        """
+        data = {
+            "name": name,
+            "path": path,
+            "initialize_with_readme": initialize_with_readme,
+            "only_allow_merge_if_all_discussions_are_resolved": only_allow_merge_if_all_discussions_are_resolved,
+            "only_allow_merge_if_pipeline_succeeds": only_allow_merge_if_pipeline_succeeds,
+        }
+        response: ResponseModel[ProjectModel] = await self._post(self.URL_PROJECTS, data)
+        if response.status_code == HTTPStatus.CREATED:
+            return response.data["id"]
+        raise GitLabError(response.data)
+
+    async def create_user(self,
+                          name: str,
+                          username: str,
+                          email: str,
+                          password: str,
+                          ) -> int:
+        """Создание пользователя в GitLab
+
+        Args:
+            name: имя нового пользователя
+            username: псевдоним(nickname) нового пользователя
+            email: почтовый адрес нового пользователя
+            password: пароль для нового пользователя
+
+        Returns:
+            идентификатор созданного пользователя
+        """
+        data = {
+            "name": name,
+            "username": username,
+            "email": email,
+            "password": password,
+        }
+        response: ResponseModel[UserModel] = await self._post(self.URL_USERS, data)
+        if response.status_code == HTTPStatus.CREATED:
+            return response.data["id"]
+        raise GitLabError(response.data)
+
+    async def list_groups(self, min_access_level: AccessLevel = 10) -> list[GroupModel]:
+        """Получение списка всех доступных групп, к которым уровень доступа не меньше min_access_level
+
+        Args:
+            min_access_level: уровень доступа
+
+        Returns:
+            список групп, удовлетворяющих условию, что уровень доступа к ним >= чем min_access_level
+        """
+        params = {"min_access_level": min_access_level}
+        response: ResponseModel[list[GroupModel]] = await self._get(self.URL_GROUPS, params)
+        if response.status_code == HTTPStatus.OK:
+            return response.data
+        raise GitLabError(response.data)
+
+    async def _add_user(self,
+                        url: str,
+                        user_id: int,
+                        access_level: AccessLevel,
+                        ) -> int:
+        """Добавление пользователя к группе/репозиторию в GitLab
+
+        Args:
+            url: сформированный url GitLab API для добавления пользователя к группе/репозиторию в GitLab
+            user_id: идентификатор пользователя
+            access_level: уровень доступа
+
+        Returns:
+            идентификатор добавленного пользователя
+        """
+        data = {
+            "user_id": user_id,
+            "access_level": access_level,
+        }
+        response: ResponseModel[UserModel] = await self._post(url, data)
+        if response.status_code == HTTPStatus.CREATED:
+            return response.data["id"]
+        raise GitLabError(response.data)
+
+    async def _create_group(self,
+                            name: str,
+                            path: str,
+                            parent_id: int | None = None,
+                            ) -> int:
+        """Создание группы/подгруппы в GitLab
+
+        Args:
+            name: наименование новой группы/подгруппы
+            path: путь до новой группы/подгруппы
+            parent_id: идентификатор родительской группы (если создается подгруппа)
+
+        Returns:
+            идентификатор созданной группы/подгруппы
+        """
+        data = {
+            "name": name,
+            "path": path,
+            "parent_id": parent_id,
+        }
+        response: ResponseModel[GroupModel] = await self._post(self.URL_GROUPS, data)
+        if response.status_code == HTTPStatus.CREATED:
+            return response.data["id"]
+        raise GitLabError(response.data)

--- a/src/routers/api/service.py
+++ b/src/routers/api/service.py
@@ -11,19 +11,3 @@ async def ping() -> PlainTextResponse:
     Должен отвечать `pong` при доступности и работоспособности приложения
     """
     return PlainTextResponse("pong")
-
-
-from aiohttp import ClientSession
-
-from src.repository.http_requests.gitlab import GitLabHTTPv4
-
-
-@service_router.get("/debug", summary="Проверка доступности API")
-async def debug() -> PlainTextResponse:
-    """Метод проверки доступности API
-
-    Должен отвечать `pong` при доступности и работоспособности приложения
-    """
-    async with ClientSession("http://localhost", headers={"PRIVATE-TOKEN": "test-token-123"}) as session:
-        gitlab_http = GitLabHTTPv4(session)
-        return await gitlab_http.create_group("cool", "cool")

--- a/src/routers/api/service.py
+++ b/src/routers/api/service.py
@@ -11,3 +11,19 @@ async def ping() -> PlainTextResponse:
     Должен отвечать `pong` при доступности и работоспособности приложения
     """
     return PlainTextResponse("pong")
+
+
+from aiohttp import ClientSession
+
+from src.repository.http_requests.gitlab import GitLabHTTPv4
+
+
+@service_router.get("/debug", summary="Проверка доступности API")
+async def debug() -> PlainTextResponse:
+    """Метод проверки доступности API
+
+    Должен отвечать `pong` при доступности и работоспособности приложения
+    """
+    async with ClientSession("http://localhost", headers={"PRIVATE-TOKEN": "test-token-123"}) as session:
+        gitlab_http = GitLabHTTPv4(session)
+        return await gitlab_http.create_group("cool", "cool")

--- a/tests/integration_tests.sh
+++ b/tests/integration_tests.sh
@@ -9,6 +9,7 @@ GITLAB_CONTAINERS=(
     gitlab/gitlab-ee:16.7.3-ee.0    gitlab_16.7
 )
 # # # # # #
+docker stop $(docker ps -a -q --filter name=gitlab)
 
 for i in ${!GITLAB_CONTAINERS[*]}; do
     [[ $((i % 2)) == 1 ]] && continue  # skip if i - odd number
@@ -66,7 +67,7 @@ for i in ${!GITLAB_CONTAINERS[*]}; do
             token.save!"
     fi
 
-    ROOT_PERSONAL_ACCESS_TOKEN=$ROOT_PERSONAL_ACCESS_TOKEN $PYTHON_PATH -m coverage run -m pytest "$TESTS_DIR"
+    ROOT_PERSONAL_ACCESS_TOKEN=$ROOT_PERSONAL_ACCESS_TOKEN $PYTHON_PATH -m coverage run -m pytest "$TESTS_DIR" -m integration
 
     docker stop "$DOCKER_NAME"
 done

--- a/tests/repository/http_requests/conftest.py
+++ b/tests/repository/http_requests/conftest.py
@@ -1,6 +1,17 @@
+import os
+from collections.abc import AsyncGenerator
 from typing import Any
 
 import pytest
+from aiohttp import ClientSession
+
+
+@pytest.fixture()
+async def root_client_session() -> AsyncGenerator[ClientSession, None]:
+    """Возвращает ClientSession с PRIVATE-TOKEN от root пользователя"""
+    headers = {"PRIVATE-TOKEN": os.environ["ROOT_PERSONAL_ACCESS_TOKEN"]}
+    async with ClientSession("http://localhost", headers=headers) as client_session:
+        yield client_session
 
 
 @pytest.fixture()

--- a/tests/repository/http_requests/test_gitlab.py
+++ b/tests/repository/http_requests/test_gitlab.py
@@ -6,7 +6,7 @@ from uuid import uuid4
 import pytest
 
 from src.repository.http_requests.fake_http import FakeClientSession
-from src.repository.http_requests.gitlab import GitLabHTTP
+from src.repository.http_requests.gitlab import GitLabHTTPv4
 
 if TYPE_CHECKING:
     from aiohttp import ClientSession
@@ -53,7 +53,7 @@ class TestGitLabHTTP:
                          ) -> None:
         """Testing GitLabHTTP.check"""
         fake_client_session = FakeClientSession(**response_from_gitlab)
-        gitlab_http = GitLabHTTP(fake_client_session)
+        gitlab_http = GitLabHTTPv4(fake_client_session)
         assert await gitlab_http.check() is expected
 
 
@@ -64,7 +64,7 @@ class TestIntegrationGitLabHTTP:
     async def test_create_group(self, root_client_session: ClientSession) -> None:
         """Testing GitLabHTTP.create_group"""
         some_uuid = str(uuid4())
-        gitlab_http = GitLabHTTP(root_client_session)
+        gitlab_http = GitLabHTTPv4(root_client_session)
         group_id = await gitlab_http.create_group(some_uuid, some_uuid)
         groups = await gitlab_http.list_groups()
         assert group_id in (group["id"] for group in groups)

--- a/tests/repository/http_requests/test_gitlab.py
+++ b/tests/repository/http_requests/test_gitlab.py
@@ -1,9 +1,15 @@
-from typing import Any, ClassVar
+from __future__ import annotations
+
+from typing import TYPE_CHECKING, Any, ClassVar
+from uuid import uuid4
 
 import pytest
 
 from src.repository.http_requests.fake_http import FakeClientSession
 from src.repository.http_requests.gitlab import GitLabHTTP
+
+if TYPE_CHECKING:
+    from aiohttp import ClientSession
 
 
 class TestGitLabHTTP:
@@ -49,3 +55,16 @@ class TestGitLabHTTP:
         fake_client_session = FakeClientSession(**response_from_gitlab)
         gitlab_http = GitLabHTTP(fake_client_session)
         assert await gitlab_http.check() is expected
+
+
+class TestIntegrationGitLabHTTP:
+    """Integration testing class GitLabHTTP"""
+    @pytest.mark.asyncio()
+    @pytest.mark.integration()
+    async def test_create_group(self, root_client_session: ClientSession) -> None:
+        """Testing GitLabHTTP.create_group"""
+        some_uuid = str(uuid4())
+        gitlab_http = GitLabHTTP(root_client_session)
+        group_id = await gitlab_http.create_group(some_uuid, some_uuid)
+        groups = await gitlab_http.list_groups()
+        assert group_id in (group["id"] for group in groups)


### PR DESCRIPTION
- Изменения в `integration_tests.sh`
  - теперь запускаются только тесты помеченные как интеграционные (`@pytest.mark.integration`)
  - теперь перед запуском всех тестов останавливаются все запущенные контейнеры с именем по маске `gitlab*`
- Добавлен первый интеграционный тест - создание группы в GitLab